### PR TITLE
Update logging.md with a note about missing imports

### DIFF
--- a/language/built-in-functions/logging.md
+++ b/language/built-in-functions/logging.md
@@ -17,3 +17,10 @@ native func FTLogError(const value: script_ref<String>) -> Void
 native func Trace() -> Void
 native func TraceToString() -> String
 ```
+
+Since v2.01, these declarations are not imported by default like previously.
+You must declare them yourself if you want to use them, otherwise you'll get an
+`UNRESOLVED_FN` error at compilation time.
+You can create a `Logs.reds` file and copy/paste the content above. Copy the 
+file in `r6\scripts\`. Now all scripts (including yours) will have access to 
+these functions.


### PR DESCRIPTION
Add a note to inform users that log functions are not imported by default. Explain how it can be achieved manually.